### PR TITLE
Json schema parsing

### DIFF
--- a/test/data/swagger2.json
+++ b/test/data/swagger2.json
@@ -49,6 +49,78 @@
           }
         }
       }
+    },
+    "Data/Article": {
+      "post": {
+        "summary": "get info from the system",
+        "description": "",
+        "operationId": "infoAPI",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [{
+          "name": "Input",
+          "in": "body",
+          "required": true,
+          "schema": {
+            "$ref": "#/definitions/articleRequestInput"
+          },
+          "description": "damien"
+        }],
+        "responses": {
+          "201": {
+            "description": "API Response when article post succed",
+            "schema": {
+              "$ref": "#/definitions/articleRequestOutput"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "articleRequestInput": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "article title",
+          "type": "string",
+          "maxLength": 60
+        },
+        "writer": {
+          "description": "writer name",
+          "type": "string",
+          "maxLength": 270
+        },
+        "kind": {
+          "description": "kind of article",
+          "type": "string",
+          "maxLength": 255
+        }
+      },
+      "required":["title","writer"],
+      "example":{
+        "title": "Postman To Swagger is so cool!",
+        "writer": "damien"
+      }
+    },
+    "articleRequestOutput": {
+      "type": "object",
+      "properties": {
+        "Publishing": {
+          "description": "Publishing information",
+          "type": "string",
+          "maxLength": 255
+        },
+        "note": {
+          "description": "article given note",
+          "type": "number"
+        }
+      },
+      "required":["note"],
+      "example":{
+        "note": "5/5"
+      }
     }
   }
 }


### PR DESCRIPTION
Hi,

I improve swagger2-to-postman to add some common use cases about JSON schema that can be provided within swagger spec.

I add exemple in swagger2.json. When generated it now, it creates:

```
{
 "id": "0662384e-6fbd-41f2-9669-d27254753fca",
 "name": "My API",
 "description": "My API",
 "order": [],
 "folders": [
  {
   "id": "963fdf31-2a25-44bf-8fec-428e85dfe78e",
   "name": "LoginAPI",
   "description": "Folder for LoginAPI",
   "order": [
    "8861b38d-b0df-427f-81ff-0c9680dc4d21"
   ],
   "collection_name": "My API",
   "collection_id": "0662384e-6fbd-41f2-9669-d27254753fca",
   "collection": "0662384e-6fbd-41f2-9669-d27254753fca"
  },
  {
   "id": "46ba1f10-73a3-4283-8940-37716af4bfe9",
   "name": "Article",
   "description": "Folder for Article",
   "order": [
    "511251fc-82c4-44e1-98fe-cf6daabab9d4"
   ],
   "collection_name": "My API",
   "collection_id": "0662384e-6fbd-41f2-9669-d27254753fca",
   "collection": "0662384e-6fbd-41f2-9669-d27254753fca"
  }
 ],
 "timestamp": 1413302258635,
 "synced": false,
 "requests": [
  {
   "id": "8861b38d-b0df-427f-81ff-0c9680dc4d21",
   "headers": "",
   "url": "{{endPoint}}/Authorization/LoginAPI",
   "pathVariables": {},
   "preRequestScript": "",
   "method": "POST",
   "data": [
    {
     "key": "UserName",
     "value": "{{UserName}}",
     "type": "text",
     "enabled": true
    },
    {
     "key": "Password",
     "value": "{{Password}}",
     "type": "text",
     "enabled": true
    }
   ],
   "dataMode": "params",
   "description": "",
   "descriptionFormat": "html",
   "time": 1458227598140,
   "version": 2,
   "responses": [],
   "tests": "",
   "collectionId": "0662384e-6fbd-41f2-9669-d27254753fca",
   "synced": false,
   "name": "Authenticates you to the system and produces a session token that will be used for future calls"
  },
  {
   "id": "511251fc-82c4-44e1-98fe-cf6daabab9d4",
   "headers": "",
   "url": "{{endPoint}}/Data/Article",
   "pathVariables": {},
   "preRequestScript": "",
   "method": "POST",
   "data": "{\n    \"title\": \"Postman To Swagger is so cool!\",\n    \"writer\": \"damien\"\n}",
   "dataMode": "raw",
   "description": "",
   "descriptionFormat": "html",
   "time": 1458227598140,
   "version": 2,
   "responses": [],
   "tests": "tests[\"Status code is 201\"] = responseCode.code === 201;\nif(responseCode.code === 201){\n\tvar data = JSON.parse(responseBody);\n\tvar schema={\n    \"type\": \"object\",\n    \"properties\": {\n        \"Publishing\": {\n            \"description\": \"Publishing information\",\n            \"type\": \"string\",\n            \"maxLength\": 255\n        },\n        \"note\": {\n            \"description\": \"article given note\",\n            \"type\": \"number\"\n        }\n    },\n    \"required\": [\n        \"note\"\n    ],\n    \"example\": {\n        \"note\": \"5/5\"\n    }\n};\n\ttests[\"Response Body respect JSON schema documentation\"] = tv4.validate(data, schema);\n\tif(tests[\"Response Body respect JSON schema documentation\"] === false){\n\t\tconsole.log(tv4.error);\n\t}\n}\n",
   "collectionId": "0662384e-6fbd-41f2-9669-d27254753fca",
   "synced": false,
   "name": "get info from the system"
  }
 ]
}
```

As you can see:
- the "data" node is filled using the Swagger JSON schema example node
- the "tests" node implements a verification when a schema is given for success status (200 to 299)

As a result, a default body and default tests can be generated from swagger spec:
![image](https://cloud.githubusercontent.com/assets/12717418/13850914/56c68820-ec5c-11e5-91a8-3ce0a3879f26.png)
![image](https://cloud.githubusercontent.com/assets/12717418/13850926/5e310ae0-ec5c-11e5-9c78-6d3b50b9c134.png)

Let me know what you think of it.
