### PR TITLE
add configuration option to include query string parameters in the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,23 @@ Convert your Swagger 2.0 JSON:
 
 Check the result:
 
-    convertResult.status === "failed" 
+    convertResult.status === "failed"
 for unsuccessful conversions. Check convertResult.message
 
     convertResult.status === "passed"
 for successful conversions. Check convertResult.collection for the Postman collection JSON
 
+
+Optional Configuration Parameters:
+The constructor can also take in a map of configuration options
+
+~~~
+var options = {
+  includeQueryParams: false
+};
+
+var swaggerConverter = new Swagger2Postman(options);
+~~~
+
+valid options are:
+includeQueryParams - (default true) Include query string parameters in the request url.

--- a/convert.js
+++ b/convert.js
@@ -9,7 +9,7 @@ var uuid = require('node-uuid'),
     },
 
     Swagger2Postman = jsface.Class({
-        constructor: function () {
+        constructor: function (options) {
             this.collectionJson = {
                 'id': '',
                 'name': '',
@@ -26,6 +26,11 @@ var uuid = require('node-uuid'),
             this.baseParams = {};
             this.logger = function () {
             };
+
+            this.options = options || {};
+
+            this.options.includeQueryParams = typeof (this.options.includeQueryParams) == 'undefined' ?
+                                                        true : this.options.includeQueryParams;
         },
 
         setLogger: function (func) {
@@ -209,7 +214,7 @@ var uuid = require('node-uuid'),
             for (param in thisParams) {
                 if (thisParams.hasOwnProperty(param) && thisParams[param]) {
                     this.logger('Processing param: ' + JSON.stringify(param));
-                    if (thisParams[param].in === 'query') {
+                    if (thisParams[param].in === 'query' && this.options.includeQueryParams !== false) {
                         if (!hasQueryParams) {
                             hasQueryParams = true;
                             request.url += '?';

--- a/test/converter-spec.js
+++ b/test/converter-spec.js
@@ -27,4 +27,20 @@ describe('the converter', function () {
         expect(convertResult.collection.requests[0]).to.have.key('currentHelper');
         expect(convertResult.collection.requests[0]).to.have.key('helperAttributes');
     });
+
+    it('should obey the includeQueryParams option', function () {
+        var options = {
+                includeQueryParams: false
+            },
+            samplePath = path.join(__dirname, 'data', 'sampleswagger.json'),
+            swagger = require(samplePath),
+            converterWithOptions = new Swagger2Postman(options),
+            convertWithOptionsResult = converterWithOptions.convert(swagger),
+            converterWithoutOptions = new Swagger2Postman(),
+            convertWithoutOptionsResult = converterWithoutOptions.convert(swagger);
+        // Make sure that currentHelper and helperAttributes are processed
+
+        expect(convertWithOptionsResult.collection.requests[3].url.indexOf('{') == -1);
+        expect(convertWithoutOptionsResult.collection.requests[3].url.indexOf('{') > 0);
+    });
 });


### PR DESCRIPTION
Our API allows query string parameters to be set, but if they are in the url and blank, will cause issues in the backend service.  More often than not they are not needed.  