### PR TITLE
remove verbose query params from path, like: {?paramA,paramB}

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -327,9 +327,12 @@ var uuidv4 = require('uuid/v4'),
                 i,
                 verb;
 
+            // remove verbose query params from path, like: {?paramA,paramB} 
             // replace path variables {petId} with :petId
             if (path) {
-                path = path.replace(/{/g, ':').replace(/}/g, '');
+                path = path.replace(/{[?][a-zA-Z0-9_,]+}/g, '')
+                    .replace(/{/g, ':')
+                    .replace(/}/g, '');
             }
 
             for (i = 0; i < numVerbs; i++) {


### PR DESCRIPTION
Spring swagger2 exported path values create entries like this one:

`"/activity/{user}{?from,to}"`

The result is a non importable json entry for Postman, as the Query Params (optional or not) are set twice, the second time with the right format, following the previous example:

`"url": "{{scheme}}://{{host}}:{{port}}/service/activity/:user:?from,to?from={{from}}&to={{to}}",`

The fix prevents this malformed entry and transforms it to:
`"url": "{{scheme}}://{{host}}:{{port}}/service/activity/:user?from={{from}}&to={{to}}",`

What is a valid entry and works fine with Postman JSON Import
            