### PR TITLE
#46 - Support transforming swagger variable names to specified Postma…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 # Idea
 .idea/
 
+#VS Code
+.vscode
+
 #################  
 ## npm
 #################
 
 npm-debug.log
 node_modules/
+

--- a/README.md
+++ b/README.md
@@ -55,5 +55,54 @@ var options = {
 var swaggerConverter = new Swagger2Postman(options);
 ```
 
-**valid options are:**
-includeQueryParams - (default true) Include query string parameters in the request url.
+**Valid options are:**
+
+* includeQueryParams - (default true) Include query string parameters in the request url.
+* transforms - (default empty) Map used to transform Swagger variables to differently named Postman variables. See [Transforms](#transforms) section below for details.
+
+**Transforms**
+
+```js
+this.options = {
+   transforms: {
+        header: {
+            '<SWAGGER HEADER NAME>': '<POSTMAN REPLACEMENT>',
+       }, path: {
+            '<SWAGGER PATH VARIABLE NAME>': '<POSTMAN REPLACEMENT>',
+      }, formData: {
+            '<SWAGGER FORMDATA VARIABLE NAME>': '<POSTMAN REPLACEMENT>',
+      }, body: {
+            '<SWAGGER BODY VARIABLE NAME>': '<POSTMAN REPLACEMENT>',
+      }
+   }
+}
+```
+
+The <POSTMAN REPLACEMENT> must contain the wrapping double-curly braces ({{...}}). The <POSTMAN REPLACEMENT> may contain any other hardcoded text/values as well. For instance, a common need for this is setting an Authorization HTTP header, that requires a Bearer prefix, for example:
+
+```js
+this.options = {
+   transforms: {
+        header: {
+           'Authorization': 'Bearer {{ACCESS_TOKEN}}'
+        }
+   }
+}
+```
+
+An example initializing the Swagger2Postman converter w/ transform parameters is as follows:
+
+```js
+converter = new Swagger2Postman({
+    includeQueryParams: false,
+    transforms: {
+        header: {
+            'api-key': '{{API_KEY}}',
+            'Authorization': 'Bearer {{ACCESS_TOKEN}}',
+        },
+        path: {
+            'ownerId': '{{OWNER_ID}}'
+        }
+    }
+});
+```

--- a/test/converter-spec.js
+++ b/test/converter-spec.js
@@ -56,7 +56,7 @@ describe('the converter', function () {
         expect(convertWithoutOptionsResult.collection.requests[3].url.indexOf('{') > 0).to.be(true);
     });
 
-    it('should convert path paramters to postman-compatible paramters', function () {
+    it('should convert path parameters to postman-compatible parameters', function () {
         var samplePath = path.join(__dirname, 'data', 'swagger2-with-params.json'),
             swagger = require(samplePath),
             converter = new Swagger2Postman(),
@@ -65,5 +65,28 @@ describe('the converter', function () {
         expect(convertResult.collection.requests[0].pathVariables.ownerId == '42').to.be(true);
         expect(convertResult.collection.requests[0].url.indexOf(':ownerId') > -1).to.be(true);
         expect(convertResult.collection.requests[0].url.indexOf(':petId') > -1).to.be(true);
+    });
+
+    it('should transform parameters based on options.transforms', function () {
+        var samplePath = path.join(__dirname, 'data', 'swagger2-with-transformed-params.json'),
+            swagger = require(samplePath),
+            converter = new Swagger2Postman({
+                transforms: {
+                    header: {
+                        'api-key': '{{API_KEY}}',
+                        'Authorization': 'Bearer {{ACCESS_TOKEN}}',
+                        'withDefaultValue': '{{WITH_DEFAULT_VALUE}}'
+                    },
+                    path: {
+                        'ownerId': '{{OWNER_ID}}'
+                    }
+                }
+            }),
+            convertResult = converter.convert(swagger);
+
+        expect(convertResult.collection.requests[0].pathVariables.ownerId).to.be('{{OWNER_ID}}');
+        expect(convertResult.collection.requests[0].pathVariables.petId).to.be('{{petId}}');
+        expect(convertResult.collection.requests[0].headers).to.be(
+                'api-key: {{API_KEY}}\nAuthorization: Bearer {{ACCESS_TOKEN}}\nwithDefaultValue: 42\n');
     });
 });

--- a/test/data/swagger2-with-transformed-params.json
+++ b/test/data/swagger2-with-transformed-params.json
@@ -1,0 +1,65 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "My API",
+    "version": "1.0.0",
+    "title": "Awesome Pets API",
+    "termsOfService": "http://www.domain.com",
+    "contact": {
+      "name": "support@domain.com"
+    }
+  },
+  "basePath": "/",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/owner/{ownerId}/pet/{petId}": {
+      "post": {
+        "summary": "Find pets belonging to a owner",
+        "description": "",
+        "operationId": "findPetsOfOwners",
+        "parameters": [{
+          "in": "path",
+          "name": "ownerId",
+          "description": "Should be transformed to Postman variable: {{OWNER_ID}}",
+          "required": true,
+          "type": "integer"
+        }, {
+          "in": "path",
+          "name": "petId",
+          "description": "Do NOT transform! Postman variable: {{petId}}",
+          "required": true,
+          "type": "integer"
+        }, {
+          "in": "header",
+          "name": "api-key",
+          "description": "Transform to Postman variable: {{API_KEY}}",
+          "required": true,
+          "type": "string"          
+        }, {
+          "in": "header",
+          "name": "Authorization",
+          "description": "Transform to Postman variable: Bearer {{ACCESS_TOKEN}}",
+          "required": true,
+          "type": "string"          
+        }, {
+          "in": "header",
+          "name": "withDefaultValue",
+          "description": "Should inject the default value and not any variable: 42",
+          "required": true,
+          "type": "integer",
+          "default": 42
+        }],
+        "responses": {
+          "200": {
+            "description": "Pet found successfully.",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
…n variables.

This adds a new 'transforms' key to the `options` object in the format:

```
this.options = {
   transforms: {
        header: {
            '<SWAGGER HEADER NAME>': '<POSTMAN REPLACEMENT>',
       }, path: {
            '<SWAGGER PATH VARIABLE NAME>': '<POSTMAN REPLACEMENT>',
      }, formData: {
            '<SWAGGER FORMDATA VARIABLE NAME>': '<POSTMAN REPLACEMENT>',
      }, body: {
            '<SWAGGER BODY VARIABLE NAME>': '<POSTMAN REPLACEMENT>',
      }
   }
}
```

The `<POSTMAN REPLACEMENT>` must contain the  wrapping double-curly braces (`{{...}}`). The `<POSTMAN REPLACEMENT>` may contain any other hardcoded text/values as well. For instance, a common need for this is setting an `Authorization` HTTP header, that requires a `Bearer ` prefix, for example:

```
this.options = {
   transforms: {
        header: {
           'Authorization': 'Bearer {{ACCESS_TOKEN}}'
        }
   }
}
```

An example initializing the Swagger2Postman converter w/ transform parameters is as follows:

```
 converter = new Swagger2Postman({
                transforms: {
                    header: {
                        'api-key': '{{API_KEY}}',
                        'Authorization': 'Bearer {{ACCESS_TOKEN}}',
                    },
                    path: {
                        'ownerId': '{{OWNER_ID}}'
                    }
                }
            })
```